### PR TITLE
Hotfix - Timeout na compressão de imagens menores que o tamanho desejado.

### DIFF
--- a/src/main/java/br/com/ottimizza/application/services/ImageCompressorService.java
+++ b/src/main/java/br/com/ottimizza/application/services/ImageCompressorService.java
@@ -35,7 +35,9 @@ public class ImageCompressorService {
 
         write(imageTemporaryPath, imageInputStream);
 
+        System.out.println("Compressing...");
         BufferedImage bi = imageUtilities.compress(imageTemporaryFile, size, removeTransparency, higherQuality);
+        System.out.println("Image Compressed...");
 
         imageUtilities.writeFile(imageTemporaryFile, bi);
 

--- a/src/main/java/br/com/ottimizza/application/services/ImageCompressorService.java
+++ b/src/main/java/br/com/ottimizza/application/services/ImageCompressorService.java
@@ -35,9 +35,7 @@ public class ImageCompressorService {
 
         write(imageTemporaryPath, imageInputStream);
 
-        System.out.println("Compressing...");
         BufferedImage bi = imageUtilities.compress(imageTemporaryFile, size, removeTransparency, higherQuality);
-        System.out.println("Image Compressed...");
 
         imageUtilities.writeFile(imageTemporaryFile, bi);
 

--- a/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
+++ b/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
@@ -63,9 +63,13 @@ public class ImageUtilities { // @formatter:off
 
     private BufferedImage getScaledInstance(BufferedImage img, int targetWidth, int targetHeight, Object hint,
             boolean higherQuality) {
+        System.out.println("Getting Type...");
         int type = (img.getTransparency() == Transparency.OPAQUE) ? BufferedImage.TYPE_INT_RGB
                 : BufferedImage.TYPE_INT_ARGB;
+        System.out.println("Copying Image...");
         BufferedImage ret = (BufferedImage) img;
+        
+        System.out.println("Initializing w & h...");
         int w, h;
 
         System.out.println(MessageFormat.format("Target Width {0}", targetWidth));

--- a/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
+++ b/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
@@ -68,18 +68,7 @@ public class ImageUtilities { // @formatter:off
         int w, h;
 
         if (img.getWidth() > targetWidth && img.getHeight() > targetHeight) {
-            w = img.getWidth();
-            h = img.getHeight();
-
-            BufferedImage tmp = new BufferedImage(w, h, type);
-            Graphics2D g2 = tmp.createGraphics();
-            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
-            g2.drawImage(ret, 0, 0, w, h, null);
-            g2.dispose();
-
-            ret = tmp;
-            
-            return ret;
+            return img;
         }
 
         if (higherQuality) {

--- a/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
+++ b/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
@@ -78,7 +78,7 @@ public class ImageUtilities { // @formatter:off
         System.out.println(MessageFormat.format("Image Width {0}", img.getWidth()));
         System.out.println(MessageFormat.format("Image Height {0}", img.getHeight()));
 
-        if (img.getWidth() > targetWidth && img.getHeight() > targetHeight) {
+        if (targetWidth > img.getWidth() || targetHeight > img.getHeight() ) {
             System.out.println("Final size is bigger");
             return img;
         }

--- a/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
+++ b/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
@@ -68,6 +68,7 @@ public class ImageUtilities { // @formatter:off
         int w, h;
 
         if (img.getWidth() > targetWidth && img.getHeight() > targetHeight) {
+            System.out.println("Final size is bigger");
             return img;
         }
 
@@ -117,9 +118,12 @@ public class ImageUtilities { // @formatter:off
     public BufferedImage compress(BufferedImage image, int size, boolean removeTransparency, boolean higherQuality) { 
         // calcula o width x height final da imagem, baseado no tamanho
         // máximo mantendo aspect ratio.
+        System.out.println("Calculating Final Size...");
         final Dimension dimension = this.calculateFinalSize(image, size);
+        System.out.println("Final Size Calculated...");
 
         // compresses the image. 
+        System.out.println("Scaling Image...");
         BufferedImage compressed = getScaledInstance(
             image, 
             (int) dimension.getWidth(), 
@@ -127,6 +131,7 @@ public class ImageUtilities { // @formatter:off
             RenderingHints.VALUE_INTERPOLATION_BILINEAR, 
             higherQuality
         );
+        System.out.println("Image Scaled...");
 
         // removes image's transparency.
         if (removeTransparency) {

--- a/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
+++ b/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
@@ -9,6 +9,7 @@ import java.awt.image.BufferedImage;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.MessageFormat;
 
 import javax.imageio.ImageIO;
 
@@ -66,6 +67,12 @@ public class ImageUtilities { // @formatter:off
                 : BufferedImage.TYPE_INT_ARGB;
         BufferedImage ret = (BufferedImage) img;
         int w, h;
+
+        System.out.println(MessageFormat.format("Target Width {0}", targetWidth));
+        System.out.println(MessageFormat.format("Target Height {0}", targetHeight));
+
+        System.out.println(MessageFormat.format("Image Width {0}", img.getWidth()));
+        System.out.println(MessageFormat.format("Image Height {0}", img.getHeight()));
 
         if (img.getWidth() > targetWidth && img.getHeight() > targetHeight) {
             System.out.println("Final size is bigger");

--- a/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
+++ b/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
@@ -63,20 +63,11 @@ public class ImageUtilities { // @formatter:off
 
     private BufferedImage getScaledInstance(BufferedImage img, int targetWidth, int targetHeight, Object hint,
             boolean higherQuality) {
-        System.out.println("Getting Type...");
         int type = (img.getTransparency() == Transparency.OPAQUE) ? BufferedImage.TYPE_INT_RGB
                 : BufferedImage.TYPE_INT_ARGB;
-        System.out.println("Copying Image...");
         BufferedImage ret = (BufferedImage) img;
         
-        System.out.println("Initializing w & h...");
         int w, h;
-
-        System.out.println(MessageFormat.format("Target Width {0}", targetWidth));
-        System.out.println(MessageFormat.format("Target Height {0}", targetHeight));
-
-        System.out.println(MessageFormat.format("Image Width {0}", img.getWidth()));
-        System.out.println(MessageFormat.format("Image Height {0}", img.getHeight()));
 
         if (targetWidth > img.getWidth() || targetHeight > img.getHeight() ) {
             System.out.println("Final size is bigger");
@@ -129,12 +120,9 @@ public class ImageUtilities { // @formatter:off
     public BufferedImage compress(BufferedImage image, int size, boolean removeTransparency, boolean higherQuality) { 
         // calcula o width x height final da imagem, baseado no tamanho
         // máximo mantendo aspect ratio.
-        System.out.println("Calculating Final Size...");
         final Dimension dimension = this.calculateFinalSize(image, size);
-        System.out.println("Final Size Calculated...");
 
         // compresses the image. 
-        System.out.println("Scaling Image...");
         BufferedImage compressed = getScaledInstance(
             image, 
             (int) dimension.getWidth(), 
@@ -142,7 +130,6 @@ public class ImageUtilities { // @formatter:off
             RenderingHints.VALUE_INTERPOLATION_BILINEAR, 
             higherQuality
         );
-        System.out.println("Image Scaled...");
 
         // removes image's transparency.
         if (removeTransparency) {

--- a/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
+++ b/src/main/java/br/com/ottimizza/application/utils/ImageUtilities.java
@@ -66,6 +66,22 @@ public class ImageUtilities { // @formatter:off
                 : BufferedImage.TYPE_INT_ARGB;
         BufferedImage ret = (BufferedImage) img;
         int w, h;
+
+        if (img.getWidth() > targetWidth && img.getHeight() > targetHeight) {
+            w = img.getWidth();
+            h = img.getHeight();
+
+            BufferedImage tmp = new BufferedImage(w, h, type);
+            Graphics2D g2 = tmp.createGraphics();
+            g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, hint);
+            g2.drawImage(ret, 0, 0, w, h, null);
+            g2.dispose();
+
+            ret = tmp;
+            
+            return ret;
+        }
+
         if (higherQuality) {
             // Use multi-step technique: start with original size, then
             // scale down in multiple passes with drawImage()


### PR DESCRIPTION
## Correção de Bug

### Timeout na compressão de imagens menores que o tamanho desejado.

### Descrição:
Quando enviada uma imagem menor do que tamanho desejado, entrava em looping, pois nunca chegava ao tamanho final.

### Solução:
Retorna a própria imagem quando largura ou altura final forem maiores que a da imagem enviada.